### PR TITLE
Fix typo in i18n documentation

### DIFF
--- a/doc/reference/view-functions/code/localize-thymeleaf.html
+++ b/doc/reference/view-functions/code/localize-thymeleaf.html
@@ -1,1 +1,1 @@
-<div data-th-text="${portal.assetUrl({'_key=mystring','_locale=en'})}">Not translated</div>
+<div data-th-text="${portal.localize({'_key=mystring','_locale=en'})}">Not translated</div>


### PR DESCRIPTION
The function is called `localize`, not `assetUrl`. At least that's how it works, and how the [code reads in the implementation](https://github.com/enonic/xp/blob/master/modules/lib/lib-thymeleaf/src/main/java/com/enonic/xp/lib/thymeleaf/ThymeleafViewFunctions.java#L55).