### PR TITLE
Fixing the life cycle text

### DIFF
--- a/doc/developer/applications/index.rst
+++ b/doc/developer/applications/index.rst
@@ -14,7 +14,7 @@ Applications may even carry data, for instance, to initialize a repository or po
 
 Life Cycle
 ----------
-Applications and have the following life-cycle:
+Applications have the following statuses on its life-cycle:
 
 * installed
 * started


### PR DESCRIPTION
Improving the description of "life cycle" section.
It had a 'and' word that didn't make sense to me.
