### PR TITLE
Removing double 'that'

### DIFF
--- a/doc/developer/site/page/index.rst
+++ b/doc/developer/site/page/index.rst
@@ -18,7 +18,7 @@ Pages should be placed in the folder ``site/pages/[page-name]``
 Descriptor
 ----------
 
-The page descriptor is an XML file that that is used to define regions and custom input fields for page configuration.
+The page descriptor is an XML file that is used to define regions and custom input fields for page configuration.
 If a page does not require regions or configuration options then the descriptor may be omitted.
 
 The file must be named ``[page-name].xml``. For example, if a page component is named "default" then the file must reside at


### PR DESCRIPTION
The word 'that' was duplicated